### PR TITLE
remove zope

### DIFF
--- a/certbot_dns_aliyun/dns_aliyun.py
+++ b/certbot_dns_aliyun/dns_aliyun.py
@@ -1,12 +1,7 @@
 """DNS Authenticator for Aliyun DNS."""
 import logging
 
-import zope.interface
-
-from certbot import errors
-from certbot import interfaces
 from certbot.plugins import dns_common
-from certbot.plugins import dns_common_lexicon
 
 try:
     # Python 3.x
@@ -17,8 +12,6 @@ except:
 
 logger = logging.getLogger(__name__)
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Aliyun DNS
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ install_requires = [
     'dns-lexicon>=3.7.1',
     'mock',
     'setuptools',
-    'zope.interface',
 ]
 
 docs_extras = [

--- a/snap-constraints.txt
+++ b/snap-constraints.txt
@@ -23,10 +23,3 @@ requests==2.23.0
 requests-toolbelt==0.9.1
 six==1.15.0
 urllib3==1.25.9
-zope.component==4.6.1
-zope.deferredimport==4.3.1
-zope.deprecation==4.4.0
-zope.event==4.4
-zope.hookable==5.0.1
-zope.interface==5.1.0
-zope.proxy==4.3.5


### PR DESCRIPTION
zope has been deprecated since the release of Certbot 1.19.0 and the referenced interfaces will be removed in an upcoming version of Certbot.